### PR TITLE
Remove unused parameter collection

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -56,12 +56,12 @@ class Seeder {
 
   seedCollection() {
     // NOTE: If options.seedIfExisting data is FALSE and the collection has data, stop immediately.
-    if (!this.options.seedIfExistingData && this.collectionHasExistingData(this.collection)) return;
+    if (!this.options.seedIfExistingData && this.collectionHasExistingData()) return;
     if (this.options.data.static) this.seedCollectionWithStaticData(this.options.data.static);
     if (this.options.data.dynamic) this.seedCollectionWithDynamicData(this.options.data.dynamic);
   }
 
-  collectionHasExistingData(collection, modelCount) {
+  collectionHasExistingData(modelCount) {
     let existingCount = this.collection.find().count();
     return modelCount ? (existingCount >= modelCount) : (existingCount > 0);
   }


### PR DESCRIPTION
Collection parameter in `collectionHasExistingData` is no longer used because it is accessed through the instance directly (`this.collection`). It doesn't need to be passed as a parameter, thus has been removed in this PR.

Not related, but some other instance functions here are exposed by exporting the data and perhaps it would be nice to set them as external functions to make sure only the Seeder usage is exposed to the user of the package ? :slightly_smiling_face: 